### PR TITLE
[Fix] LocalContentColor를 Dynamic composition local로 변경

### DIFF
--- a/src/main/java/in/koreatech/koin/designsystem/Color.kt
+++ b/src/main/java/in/koreatech/koin/designsystem/Color.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.designsystem
 
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 
@@ -411,4 +412,4 @@ internal val lightColors = KoinColors(
 )
 
 val LocalColors = staticCompositionLocalOf { lightColors }
-val LocalContentColor = staticCompositionLocalOf { Color.Black }
+val LocalContentColor = compositionLocalOf { Color.Black }


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #5 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
* LocalContentColor를 Dynamic Composition Local로 변경했습니다.
  * `staticCompositionLocalOf`의 경우, 변경이 적은 값에 사용할 경우, 성능 상 이점을 가지지만 자주 변경되는 값에 사용할 경우 하위 Composable이 모두 다시 recomposition되는 특징을 가지고 있습니다.
  * 반면, `compositionLocalOf`은 Composition local이 적용된 부분만 recomposition이 되기 때문에 `LocalContentColor`와 같이 자주 변경되는 Composition local에는 Dynamic이 적합합니다.

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다