### PR TITLE
[Feature] switch component 개발 (compose)

### DIFF
--- a/src/main/java/in/koreatech/koin/designsystem/switch/Switch.kt
+++ b/src/main/java/in/koreatech/koin/designsystem/switch/Switch.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -46,6 +47,8 @@ fun Switch(
     emphasized: Boolean = true,
     switchInteractionColors: SwitchInteractionColors = SwitchDefaults.switchInteractionColors()
 ) {
+    val density = LocalDensity.current
+
     var isChecked by remember(checked) { mutableStateOf(checked) }
     val animateOffset = remember { Animatable(if (isChecked) 1f else 0f) }
     LaunchedEffect(isChecked) {
@@ -119,6 +122,7 @@ fun Switch(
                 ((trackWidth - thumbWidth) * animateOffset.value)
             )
         }
+        var borderDpSize by remember { mutableStateOf(2.3.dp) }
         Box(
             modifier = Modifier
                 .fillMaxHeight(0.7f)
@@ -147,13 +151,16 @@ fun Switch(
                         },
                         shape = CircleShape
                     )
-                    .onSizeChanged { thumbWidth = it.width },
+                    .onSizeChanged {
+                        thumbWidth = it.width
+                        borderDpSize = with(density) { (it.height * 0.1f).toDp() }
+                    },
                 contentAlignment = Alignment.Center
             ) {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(vertical = 2.3.dp, horizontal = 2.3.dp)
+                        .padding(all = borderDpSize)
                         .background(
                             color = if (isChecked) {
                                 if (emphasized) switchStateColors.selectedSwitchColors.contentColor else switchStateColors.notEmphasizedSwitchColors.contentColor
@@ -175,7 +182,7 @@ object SwitchDefaults {
         hoverSwitchStateColors: SwitchStateColors = hoverSwitchStateColors(),
         touchSwitchStateColors: SwitchStateColors = touchSwitchStateColors(),
         focusSwitchStateColors: SwitchStateColors = focusSwitchStateColors(),
-        disabledSwitchStateColors: SwitchStateColors = disabledFocusSwitchStateColors(),
+        disabledSwitchStateColors: SwitchStateColors = disabledFocusSwitchStateColors()
     ): SwitchInteractionColors = SwitchInteractionColors(
         defaultSwitchStateColors = defaultSwitchStateColors,
         hoverSwitchStateColors = hoverSwitchStateColors,
@@ -322,7 +329,7 @@ class SwitchStateColors internal constructor(
 class SwitchColors internal constructor(
     val containerColor: Color,
     val contentColor: Color,
-    val contentBorderColor: Color,
+    val contentBorderColor: Color
 )
 
 @Preview

--- a/src/main/java/in/koreatech/koin/designsystem/switch/Switch.kt
+++ b/src/main/java/in/koreatech/koin/designsystem/switch/Switch.kt
@@ -1,0 +1,364 @@
+package `in`.koreatech.koin.designsystem.switch
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.FocusInteraction
+import androidx.compose.foundation.interaction.HoverInteraction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.designsystem.KoinTheme
+
+@Composable
+fun Switch(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+    disabled: Boolean = false,
+    emphasized: Boolean = true,
+    switchInteractionColors: SwitchInteractionColors = SwitchDefaults.switchInteractionColors()
+) {
+    var isChecked by remember(checked) { mutableStateOf(checked) }
+    val animateOffset = remember { Animatable(if (isChecked) 1f else 0f) }
+    LaunchedEffect(isChecked) {
+        animateOffset.animateTo(if (isChecked) 1f else 0f, animationSpec = tween(durationMillis = 300))
+    }
+
+    val interactionSource = remember { MutableInteractionSource() }
+    var isPressed by remember { mutableStateOf(false) }
+    var isFocused by remember { mutableStateOf(false) }
+    var isHovered by remember { mutableStateOf(false) }
+
+    val switchStateColors = remember(disabled, isPressed, isFocused, isHovered) {
+        if (disabled) {
+            switchInteractionColors.disabledSwitchStateColors
+        } else if (isPressed) {
+            switchInteractionColors.touchSwitchStateColors
+        } else if (isFocused) {
+            switchInteractionColors.focusSwitchStateColors
+        } else if (isHovered) {
+            switchInteractionColors.hoverSwitchStateColors
+        } else {
+            switchInteractionColors.defaultSwitchStateColors
+        }
+    }
+
+    LaunchedEffect(interactionSource) {
+        interactionSource.interactions.collect { interaction ->
+            when (interaction) {
+                is PressInteraction.Press -> isPressed = true
+                is PressInteraction.Release,
+                is PressInteraction.Cancel -> isPressed = false
+                is FocusInteraction.Focus -> isFocused = true
+                is FocusInteraction.Unfocus -> isFocused = false
+                is HoverInteraction.Enter -> isHovered = true
+                is HoverInteraction.Exit -> isHovered = false
+            }
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .height(33.dp)
+            .aspectRatio(1.8f)
+            .then(
+                if (isFocused) {
+                    Modifier.border(
+                        width = 2.dp,
+                        color = switchStateColors.focusBorderColor,
+                        shape = RoundedCornerShape(20.dp)
+                    )
+                } else {
+                    Modifier
+                }
+            )
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                enabled = !disabled
+            ) {
+                isChecked = !isChecked
+                onCheckedChange(isChecked)
+            }
+            .hoverable(interactionSource = interactionSource)
+            .focusable(interactionSource = interactionSource),
+        contentAlignment = Alignment.Center
+    ) {
+        var trackWidth by remember { mutableIntStateOf(0) }
+        var thumbWidth by remember { mutableIntStateOf(0) }
+        var thumbOffset by remember(animateOffset.value, trackWidth, thumbWidth) {
+            mutableFloatStateOf(
+                ((trackWidth - thumbWidth) * animateOffset.value)
+            )
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxHeight(0.7f)
+                .aspectRatio(2.1f)
+                .background(
+                    color = if (isChecked) {
+                        if (emphasized) switchStateColors.selectedSwitchColors.containerColor else switchStateColors.notEmphasizedSwitchColors.containerColor
+                    } else {
+                        switchStateColors.unselectedSwitchColors.containerColor
+                    },
+                    shape = CircleShape
+                )
+                .onSizeChanged { trackWidth = it.width },
+            Alignment.CenterStart
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight(if (isFocused) 0.9f else 1f)
+                    .aspectRatio(1f)
+                    .offset { IntOffset(thumbOffset.toInt(), 0) }
+                    .background(
+                        color = if (isChecked) {
+                            if (emphasized) switchStateColors.selectedSwitchColors.contentBorderColor else switchStateColors.notEmphasizedSwitchColors.contentBorderColor
+                        } else {
+                            switchStateColors.unselectedSwitchColors.contentBorderColor
+                        },
+                        shape = CircleShape
+                    )
+                    .onSizeChanged { thumbWidth = it.width },
+                contentAlignment = Alignment.Center
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(vertical = 2.3.dp, horizontal = 2.3.dp)
+                        .background(
+                            color = if (isChecked) {
+                                if (emphasized) switchStateColors.selectedSwitchColors.contentColor else switchStateColors.notEmphasizedSwitchColors.contentColor
+                            } else {
+                                switchStateColors.unselectedSwitchColors.contentColor
+                            },
+                            shape = CircleShape
+                        )
+                )
+            }
+        }
+    }
+}
+
+object SwitchDefaults {
+    @Composable
+    fun switchInteractionColors(
+        defaultSwitchStateColors: SwitchStateColors = defaultSwitchStateColors(),
+        hoverSwitchStateColors: SwitchStateColors = hoverSwitchStateColors(),
+        touchSwitchStateColors: SwitchStateColors = touchSwitchStateColors(),
+        focusSwitchStateColors: SwitchStateColors = focusSwitchStateColors(),
+        disabledSwitchStateColors: SwitchStateColors = disabledFocusSwitchStateColors(),
+    ): SwitchInteractionColors = SwitchInteractionColors(
+        defaultSwitchStateColors = defaultSwitchStateColors,
+        hoverSwitchStateColors = hoverSwitchStateColors,
+        touchSwitchStateColors = touchSwitchStateColors,
+        focusSwitchStateColors = focusSwitchStateColors,
+        disabledSwitchStateColors = disabledSwitchStateColors
+    )
+
+    @Composable
+    fun defaultSwitchStateColors(
+        selectedSwitchColors: SwitchColors = selectedSwitchColors(),
+        unselectedSwitchColors: SwitchColors = unselectedSwitchColors(),
+        notEmphasizedSwitchColors: SwitchColors = notEmphasizedSwitchColors(),
+        focusBorderColor: Color = KoinTheme.colors.primary700
+    ): SwitchStateColors = SwitchStateColors(
+        selectedSwitchColors = selectedSwitchColors,
+        unselectedSwitchColors = unselectedSwitchColors,
+        notEmphasizedSwitchColors = notEmphasizedSwitchColors,
+        focusBorderColor = focusBorderColor
+    )
+
+    @Composable
+    fun hoverSwitchStateColors(
+        selectedSwitchColors: SwitchColors = selectedSwitchColors(containerColor = KoinTheme.colors.primary600),
+        unselectedSwitchColors: SwitchColors = unselectedSwitchColors(contentBorderColor = KoinTheme.colors.neutral600),
+        notEmphasizedSwitchColors: SwitchColors = notEmphasizedSwitchColors(
+            containerColor = KoinTheme.colors.neutral600,
+            contentBorderColor = KoinTheme.colors.neutral600
+        ),
+        focusBorderColor: Color = KoinTheme.colors.primary700
+    ): SwitchStateColors = SwitchStateColors(
+        selectedSwitchColors = selectedSwitchColors,
+        unselectedSwitchColors = unselectedSwitchColors,
+        notEmphasizedSwitchColors = notEmphasizedSwitchColors,
+        focusBorderColor = focusBorderColor
+    )
+
+    @Composable
+    fun touchSwitchStateColors(
+        selectedSwitchColors: SwitchColors = selectedSwitchColors(
+            containerColor = KoinTheme.colors.primary800,
+            contentBorderColor = KoinTheme.colors.primary800
+        ),
+        unselectedSwitchColors: SwitchColors = unselectedSwitchColors(contentBorderColor = KoinTheme.colors.neutral800),
+        notEmphasizedSwitchColors: SwitchColors = notEmphasizedSwitchColors(
+            containerColor = KoinTheme.colors.neutral800,
+            contentBorderColor = KoinTheme.colors.neutral800
+        ),
+        focusBorderColor: Color = KoinTheme.colors.primary700
+    ): SwitchStateColors = SwitchStateColors(
+        selectedSwitchColors = selectedSwitchColors,
+        unselectedSwitchColors = unselectedSwitchColors,
+        notEmphasizedSwitchColors = notEmphasizedSwitchColors,
+        focusBorderColor = focusBorderColor
+    )
+
+    @Composable
+    fun focusSwitchStateColors(
+        selectedSwitchColors: SwitchColors = selectedSwitchColors(
+            containerColor = KoinTheme.colors.primary600,
+            contentBorderColor = KoinTheme.colors.primary600
+        ),
+        unselectedSwitchColors: SwitchColors = unselectedSwitchColors(contentBorderColor = KoinTheme.colors.neutral600),
+        notEmphasizedSwitchColors: SwitchColors = notEmphasizedSwitchColors(
+            containerColor = KoinTheme.colors.neutral600,
+            contentBorderColor = KoinTheme.colors.neutral600
+        ),
+        focusBorderColor: Color = KoinTheme.colors.primary700
+    ): SwitchStateColors = SwitchStateColors(
+        selectedSwitchColors = selectedSwitchColors,
+        unselectedSwitchColors = unselectedSwitchColors,
+        notEmphasizedSwitchColors = notEmphasizedSwitchColors,
+        focusBorderColor = focusBorderColor
+    )
+
+    @Composable
+    fun disabledFocusSwitchStateColors(
+        selectedSwitchColors: SwitchColors = selectedSwitchColors(
+            containerColor = KoinTheme.colors.neutral400,
+            contentBorderColor = KoinTheme.colors.neutral400
+        ),
+        unselectedSwitchColors: SwitchColors = unselectedSwitchColors(contentBorderColor = KoinTheme.colors.neutral400),
+        notEmphasizedSwitchColors: SwitchColors = notEmphasizedSwitchColors(
+            containerColor = KoinTheme.colors.neutral400,
+            contentBorderColor = KoinTheme.colors.neutral400
+        ),
+        focusBorderColor: Color = KoinTheme.colors.primary700
+    ): SwitchStateColors = SwitchStateColors(
+        selectedSwitchColors = selectedSwitchColors,
+        unselectedSwitchColors = unselectedSwitchColors,
+        notEmphasizedSwitchColors = notEmphasizedSwitchColors,
+        focusBorderColor = focusBorderColor
+    )
+
+    @Composable
+    fun selectedSwitchColors(
+        containerColor: Color = KoinTheme.colors.primary700,
+        contentColor: Color = KoinTheme.colors.neutral0,
+        contentBorderColor: Color = KoinTheme.colors.primary700
+    ) = SwitchColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        contentBorderColor = contentBorderColor
+    )
+
+    @Composable
+    fun unselectedSwitchColors(
+        containerColor: Color = Color(0xFFE1E1E1),
+        contentColor: Color = KoinTheme.colors.neutral0,
+        contentBorderColor: Color = KoinTheme.colors.neutral700
+    ) = SwitchColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        contentBorderColor = contentBorderColor
+    )
+
+    @Composable
+    fun notEmphasizedSwitchColors(
+        containerColor: Color = KoinTheme.colors.neutral700,
+        contentColor: Color = KoinTheme.colors.neutral0,
+        contentBorderColor: Color = KoinTheme.colors.neutral700
+    ) = SwitchColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        contentBorderColor = contentBorderColor
+    )
+}
+
+class SwitchInteractionColors internal constructor(
+    val defaultSwitchStateColors: SwitchStateColors,
+    val hoverSwitchStateColors: SwitchStateColors,
+    val touchSwitchStateColors: SwitchStateColors,
+    val focusSwitchStateColors: SwitchStateColors,
+    val disabledSwitchStateColors: SwitchStateColors
+
+)
+class SwitchStateColors internal constructor(
+    val selectedSwitchColors: SwitchColors,
+    val unselectedSwitchColors: SwitchColors,
+    val notEmphasizedSwitchColors: SwitchColors,
+    val focusBorderColor: Color
+)
+
+class SwitchColors internal constructor(
+    val containerColor: Color,
+    val contentColor: Color,
+    val contentBorderColor: Color,
+)
+
+@Preview
+@Composable
+private fun SwitchCheckedPreview() {
+    Switch(
+        checked = true,
+        onCheckedChange = {}
+    )
+}
+
+@Preview
+@Composable
+private fun SwitchUnCheckedPreview() {
+    Switch(
+        checked = false,
+        onCheckedChange = {}
+    )
+}
+
+@Preview
+@Composable
+private fun SwitchDisabledPreview() {
+    Switch(
+        checked = false,
+        disabled = true,
+        onCheckedChange = {}
+    )
+}
+
+@Preview
+@Composable
+private fun SwitchEmphasizedPreview() {
+    Switch(
+        checked = true,
+        emphasized = true,
+        onCheckedChange = {}
+    )
+}


### PR DESCRIPTION
## 개요
issue: #12 

## 개발 내용

switch component 를 개발했습니다.

| 영상 |
|:--:|
| Touch 동작 > Focus 동작 > Hover 동작 |

https://github.com/user-attachments/assets/91abfd4a-bff8-416c-8cee-8d84e3e2ffbc

| disabled(클릭 안됨) + focus | not emphasized |
|:--:|:--:|
| <img width="50%" alt="스크린샷 2025-11-20 110747" src="https://github.com/user-attachments/assets/24e2c3a6-534f-4ee6-af7d-01ba608adfab" /> | <img width="100%" alt="스크린샷 2025-11-20 110747" src="https://github.com/user-attachments/assets/0e28b66d-09a6-4a3a-8384-92295d1fd44c" /> |

색상은 disabled > pressed > focus > hover > default  의 우선도로 적용됩니다.
not emphasized 색상은 모든 상태에서 보유중입니다.

### Recomposition 관련
기존은 Canvas 를 이용해서 사용했습니다.
클릭당 2회씩 recomposition 되는 형태입니다.(정상)
| (legacy) Canvas 분석 |
|:--:|
|  <img width="70%" alt="스크린샷 2025-11-19 200550" src="https://github.com/user-attachments/assets/bf9da1ed-5cc7-484f-8059-1d6c12f9c066" />|

다만 recomposition 은 적어도 결국 Canvas 는 내부 요소를 전부 다시 그립니다.
그렇기에 Compose 를 통해 draw 과정을 생략(skip) 하고자 **오로지 Compose 요소로 다시 만들었습니다.**
확장, 유지 보수도 compose 가 더 좋구요

| Compose 분석 |
|:--:|
| <img width="70%" alt="스크린샷 2025-11-19 212807" src="https://github.com/user-attachments/assets/54e2bd54-513f-4b3c-beb1-430065b97bf5" /> |

Compose 도 다시 만들면서 
한번 클릭 당 recomposition 이 36 회 정도가 발생하며 2번 클릭하면 72회가 발생했습니다.

원인은 `animateTo( animationSpec = tween(durationMillis = 300) )` 의 이유로 굉장히 많은 값을 거쳐갑니다.
물론 내부 요소의 draw 등은 skip 되고 있기에 별 문제는 없을 거 같습니다.

## 논의 사항

### Custom 관련 (색상)

현재 각 색상 요소를 tree 형태로 나누었습니다.
switchInteractionColors

- defaultSwitchStateColors, hoverSwitchStateColors, touchSwitchStateColors, focusSwitchStateColors, disabledSwitchStateColors

 - - selectedSwitchColors, unselectedSwitchColors, notEmphasizedSwitchColors, focusBorderColor(Color)
 - - - containerColor(Color), contentColor(Color), contentBorderColor(Color)
 
 각 상태(hover, focus 등) 별로 selected, unselected, notEmphasized, focusBorder 의 색상을 바꿀 수 있습니다.
 구조는 깔끔해 보입니다만 **Custom 시 조금 불편합니다.**
 
| Custom 예시 |
|:--:|
| <img width="70%" alt="스크린샷 2025-11-20 103003" src="https://github.com/user-attachments/assets/c011310e-46fc-4c1d-b089-449252f87173" /> 

switchInteractionColors 를 만들고 안에 원하는 --SwitchStateColors 생성자를 호출하고 또 안에 --SwitchColors 생성자를 호출해야
정상적으로 동작합니다.
이 구조를 더 개선할 수 있는 방안을 모색 중입니다. 혹시 다른 생각이 있으시면 말씀해주세요.
가장 간단한 방법은 --SwitchColors 단계를 삭제 후 --SwitchStateColors 에서
selectedcontainerColor, selectedcontentColor, selectedcontentBorderColor ...  로 생성하는 단축하는 방법이 있긴 합니다.
 
### Custom 관련 (모양)

기본적으로 `Modifier.height or width`  를 통한 size 강제화로 크기를 변경할 수 있습니다.
기본height(33.dp) 에 1:1.8 비율 [focus 테두리 이유로 내부 padding 이 있어 좀 더 큽니다. 실질적으론 26.dp 정도의 내용입니다.]
| resize (width = 100.dp) | resize (height = 20.dp)
|:--:|:--:|
| <img width="50%" alt="스크린샷 2025-11-20 105306" src="https://github.com/user-attachments/assets/d5034aa6-b994-4fa4-bc26-7532ca0d97aa" /> | <img width="50%" alt="스크린샷 2025-11-20 105740" src="https://github.com/user-attachments/assets/18037624-7589-46c3-a297-2976cd301f95" />

**외에 border 크기, track 길이 등의 커스텀은 제공하지 않습니다. (기본적으로 부모의 길이에 맞춰 조정됨)**
따로 제공한다면 기존 component 의 비율 대비 크기 확대의 부분에서 어려움이 있을 거 같아 이렇게 작업했습니다.
혹시 다른 생각이 있으시면 말씀해주세요.
